### PR TITLE
PackageGraph: Support traits and trait-based conditionals

### DIFF
--- a/.github/workflows/swift-macos.yml
+++ b/.github/workflows/swift-macos.yml
@@ -16,7 +16,9 @@ jobs:
       - name: Setup Xcode version
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
-          xcode-version: '16.3' # contains Swift 6.1
+          # contains Swift 6.2.4 (last bump was due to concurrency compilation
+          # errors in NaiveQueueExecutor)
+          xcode-version: '26.3' 
 
       - name: Swift version
         run: swift --version

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8f6c0b60e995f8fb408d3e3596f159f01af1066634561455fadd05faeba36064",
+  "originHash" : "5427b654f43a5a3387171233473a8398ae4ddd9bad8ca2386fcb92f15bd1a045",
   "pins" : [
     {
       "identity" : "aexml",
@@ -178,6 +178,15 @@
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5fa253428866f2360c3754e88537f700ed2656b5",
         "version" : "1.4.1"
       }
     },

--- a/Package.swift
+++ b/Package.swift
@@ -78,6 +78,9 @@ let package = Package(
     .package(url: "https://github.com/sersoft-gmbh/swift-inotify", "0.4.0"..<"0.5.0"),
     .package(url: "https://github.com/apple/swift-system", from: "1.2.0"),
     .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.3"),
+
+    // Test dependencies
+    .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.4.1"),
   ],
   targets: [
     .executableTarget(name: "swift-bundler", dependencies: ["SwiftBundler"]),
@@ -229,7 +232,14 @@ let package = Package(
 
     .testTarget(
       name: "SwiftBundlerTests",
-      dependencies: ["SwiftBundler"],
+      dependencies: [
+        "SwiftBundler",
+        .product(
+          name: "ConcurrencyExtras",
+          package: "swift-concurrency-extras",
+          condition: .when(platforms: [.macOS])
+        ),
+      ],
       resources: [
         .copy("Fixtures")
       ]

--- a/Sources/SwiftBundler/Bundler/APKBundler.swift
+++ b/Sources/SwiftBundler/Bundler/APKBundler.swift
@@ -384,17 +384,13 @@ enum APKBundler: Bundler {
     toJavaSources sourcesDirectory: URL,
     targetPlatform: Platform
   ) throws(Error) {
-    let conditionalTargets = try Error.catch {
-      try packageGraph.transitiveTargets(
+    let targets = try Error.catch {
+      try packageGraph.transitiveActiveTargets(
         inProduct: product,
-        inPackage: packageGraph.rootPackage.reference
+        inPackage: packageGraph.rootPackage.reference,
+        targetPlatform: targetPlatform
       )
     }
-
-    let targets = packageGraph.activeTargets(
-      inConditionalReferences: conditionalTargets,
-      withTargetPlatform: targetPlatform
-    )
 
     var directories: [(
       location: URL,
@@ -495,17 +491,13 @@ enum APKBundler: Bundler {
     toResources resourcesDirectory: URL,
     targetPlatform: Platform
   ) throws(Error) -> ResourceCopyingResult {
-    let conditionalTargets = try Error.catch {
-      try packageGraph.transitiveTargets(
+    let targets = try Error.catch {
+      try packageGraph.transitiveActiveTargets(
         inProduct: product,
-        inPackage: packageGraph.rootPackage.reference
+        inPackage: packageGraph.rootPackage.reference,
+        targetPlatform: targetPlatform
       )
     }
-
-    let targets = packageGraph.activeTargets(
-      inConditionalReferences: conditionalTargets,
-      withTargetPlatform: targetPlatform
-    )
 
     for target in targets {
       guard let configuration = try Error.catch(do: {

--- a/Sources/SwiftBundler/Bundler/ProjectBuilder.swift
+++ b/Sources/SwiftBundler/Bundler/ProjectBuilder.swift
@@ -148,13 +148,10 @@ enum ProjectBuilder {
     processDependencies(appConfiguration.dependencies, depender: .app)
 
     let targets = try Error.catch {
-      let targets = try packageGraph.transitiveTargets(
+      try packageGraph.transitiveActiveTargets(
         inProduct: appConfiguration.product,
-        inPackage: packageGraph.rootPackage.reference
-      )
-      return packageGraph.activeTargets(
-        inConditionalReferences: targets,
-        withTargetPlatform: targetPlatform
+        inPackage: packageGraph.rootPackage.reference,
+        targetPlatform: targetPlatform
       )
     }
 

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/ConditionalTargetReference.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/ConditionalTargetReference.swift
@@ -3,16 +3,77 @@ extension SwiftPackageManager {
   struct ConditionalTargetReference: Sendable, Hashable {
     /// A reference to the underlying target.
     var target: TargetReference
-    /// A condition which dictates when this reference should be counted as
-    /// active. No conditions implies that the reference is unconditional.
-    var conditions: [TargetDependency.Condition]
+    /// Conditions that dictate when this reference should be counted as
+    /// active. Every condition must be satisfied for the target reference
+    /// to be considered active. No conditions implies that the reference
+    /// is unconditionally active.
+    var conditions: [Condition] = []
+
+    /// A condition that makes up part of a conditional target reference.
+    struct Condition: Sendable, Hashable {
+      /// The package to use when evaluating trait-based conditions.
+      var package: PackageReference
+      /// The underlying target condition.
+      var condition: TargetDependency.Condition
+    }
+
+    /// Creates a conditional reference to the given target with the given
+    /// conditions.
+    init(target: TargetReference, conditions: [Condition]) {
+      self.target = target
+      self.conditions = conditions
+    }
+
+    /// Creates a conditional reference to a target with an associated target
+    /// dependency condition. The target dependency condition must be from
+    /// the same package as the target, otherwise trait-based conditions won't
+    /// get evaluated correctly.
+    init(target: TargetReference, condition: TargetDependency.Condition?) {
+      self.target = target
+      self.conditions = [condition]
+        .compactMap { $0 }
+        .map { condition in
+          Condition(package: target.package, condition: condition)
+        }
+    }
+
+    /// Gets the reference with the given target conditions appended to its
+    /// existing conditions. Target conditions need to be associated with the
+    /// package that they came from in order for trait conditions to get
+    /// evaluated correctly.
+    func appendingConditions(
+      _ conditions: [TargetDependency.Condition],
+      from package: PackageReference
+    ) -> Self {
+      var reference = self
+      reference.conditions += conditions.map { condition in
+        Condition(package: package, condition: condition)
+      }
+      return reference
+    }
 
     /// Gets the reference with the given conditions appended to its existing
     /// conditions.
-    func appendingConditions(_ conditions: [TargetDependency.Condition]) -> Self {
+    func appendingConditions(_ conditions: [Condition]) -> Self {
       var reference = self
       reference.conditions += conditions
       return reference
+    }
+
+    /// Computes whether a conditional reference is active.
+    func isActive(targetPlatform: Platform, packageGraph: PackageGraph) -> Bool {
+      conditions.allSatisfy { condition in
+        condition.condition.isSatisfied(
+          targetPlatform: targetPlatform,
+          // The conditions that make up a conditional target reference may
+          // come from multiple different packages (because they represent
+          // all of the conditions present in a chain from the root package
+          // to the desired target). The traits used to evaluate each
+          // condition must be for the package that the condition originated
+          // from.
+          enabledTraits: packageGraph.enabledTraits[condition.package] ?? []
+        )
+      }
     }
   }
 }

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/Package.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/Package.swift
@@ -25,6 +25,8 @@ extension SwiftPackageManager {
     /// packages in a ``PackageGraph``). That's why `Dependency` is a generic
     /// parameter.
     var dependencies: [Dependency]
+    /// The package's traits.
+    var traits: [Trait]
     /// The package's products.
     var products: [String: Product]
     /// The package's targets.
@@ -44,10 +46,43 @@ extension SwiftPackageManager {
     var reference: PackageReference {
       PackageReference(identity: identity)
     }
+
+    /// Computes the traits recursively enabled by the given set of enabled traits.
+    ///
+    /// Each trait can define a list of traits that get transitively enabled
+    /// whenever the trait gets enabled. This method resolves the set of all traits
+    /// enabled (including transitively) by a given set of explicitly enabled traits.
+    ///
+    /// Unknown traits are ignored (and removed from the result).
+    func recursivelyEnabledTraits(enabledTraits: Set<String>) -> Set<String> {
+      var recursiveTraits: Set<String> = []
+
+      var queue = Array(enabledTraits)
+      while let trait = queue.popLast() {
+        guard let definition = traits.first(where: { $0.name == trait }) else {
+          if trait != "default" {
+            log.warning(
+              """
+              Unknown trait '\(trait)' (for package '\(identity)' with traits \
+              \(traits.map(\.name)))
+              """
+            )
+          }
+          continue
+        }
+
+        recursiveTraits.formUnion([trait] + definition.enabledTraits)
+        for nestedTrait in definition.enabledTraits where !queue.contains(nestedTrait) {
+          queue.append(nestedTrait)
+        }
+      }
+
+      return recursiveTraits
+    }
   }
 }
 
-extension SwiftPackageManager.Package<PackageManifest.PackageDependency> {
+extension SwiftPackageManager.Package<SwiftPackageManager.PackageDependency> {
   /// Converts a package that represents its dependencies by location into one
   /// that represents its dependencies by thin references.
   var withReferences: SwiftPackageManager.Package<SwiftPackageManager.PackageReference> {
@@ -56,8 +91,8 @@ extension SwiftPackageManager.Package<PackageManifest.PackageDependency> {
       identity: identity,
       source: source,
       localCheckout: localCheckout,
-      dependencies: dependencies.map(\.identity)
-        .map(SwiftPackageManager.PackageReference.init(identity:)),
+      dependencies: dependencies.map(\.package),
+      traits: traits,
       products: products,
       targets: targets,
       fullConfiguration: fullConfiguration,
@@ -73,6 +108,7 @@ extension SwiftPackageManager.Package: Codable {
     case source
     case localCheckout
     case dependencies
+    case traits
     case products
     case targets
     case fullConfiguration
@@ -87,6 +123,7 @@ extension SwiftPackageManager.Package: Codable {
     source = try container.decode(SwiftPackageManager.PackageSource.self, forKey: .source)
     localCheckout = try container.decode(URL.self, forKey: .localCheckout)
     dependencies = try container.decode([Dependency].self, forKey: .dependencies)
+    traits = try container.decode([SwiftPackageManager.Trait].self, forKey: .dependencies)
     products = try container.decode([String: SwiftPackageManager.Product].self, forKey: .products)
     targets = try container.decode([String: SwiftPackageManager.Target].self, forKey: .targets)
     fullConfiguration = try container.decode(PackageConfiguration?.self, forKey: .fullConfiguration)
@@ -101,6 +138,7 @@ extension SwiftPackageManager.Package: Codable {
     try container.encode(source, forKey: .source)
     try container.encode(localCheckout, forKey: .localCheckout)
     try container.encode(dependencies, forKey: .dependencies)
+    try container.encode(traits, forKey: .traits)
     try container.encode(products, forKey: .products)
     try container.encode(targets, forKey: .targets)
     try container.encode(fullConfiguration, forKey: .fullConfiguration)

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/Package.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/Package.swift
@@ -60,7 +60,11 @@ extension SwiftPackageManager {
       var queue = Array(enabledTraits)
       while let trait = queue.popLast() {
         guard let definition = traits.first(where: { $0.name == trait }) else {
-          if trait != "default" {
+          if trait == "default" {
+            // If the default trait doesn't have a definition, then it only
+            // enables itself
+            recursiveTraits.insert("default")
+          } else {
             log.warning(
               """
               Unknown trait '\(trait)' (for package '\(identity)' with traits \

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageDependency.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageDependency.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+extension SwiftPackageManager {
+  /// A package's dependency on another package.
+  struct PackageDependency: Sendable, Codable {
+    /// The target package.
+    var package: PackageReference
+    /// The traits enabled by this dependency edge.
+    ///
+    /// This doesn't necessarily include all traits that the target package
+    /// ends up getting compiled with, because the final set of traits is the
+    /// union of the traits enabled by all dependencies on a given target
+    /// package.
+    var traits: Set<String>
+    /// The location of the dependency on disk.
+    var location: PackageManifest.PackageDependency.Location
+
+    /// Gets the path to the given dependency's local checkout. If the dependency
+    /// is a local package dependency, then this returns the path to the
+    /// dependency's source on disk.
+    func localCheckout(packageDirectory: URL, checkoutsDirectory: URL) -> URL {
+      switch location {
+        case .fileSystem(let path):
+          return path
+        case .sourceControl(let location):
+          var name = location.lastPathComponent
+          let gitSuffix = ".git"
+          if name.hasSuffix(gitSuffix) {
+            name = String(name.dropLast(gitSuffix.count))
+          }
+          return checkoutsDirectory / name
+      }
+    }
+  }
+}
+
+/// This implementation isn't involved in the initial decoding of a
+/// ``PackageManifest``, only in subsequent encoding and decoding of a
+/// ``SwiftPackageManager/Package``.
+extension PackageManifest.PackageDependency.Location: Codable {
+  enum CodingKeys: String, CodingKey {
+    case localPath
+    case remoteSourceControl
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    if container.contains(.localPath) {
+      let path = try container.decode(String.self, forKey: .localPath)
+      self = .fileSystem(path: URL(fileURLWithPath: path))
+    } else {
+      let location = try container.decode(URL.self, forKey: .remoteSourceControl)
+      self = .sourceControl(url: location)
+    }
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+      case .fileSystem(let url):
+        try container.encode(url.path, forKey: .localPath)
+      case .sourceControl(let url):
+        try container.encode(url, forKey: .remoteSourceControl)
+    }
+  }
+}

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageGraph.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageGraph.swift
@@ -10,6 +10,8 @@ extension SwiftPackageManager {
     /// Transitive dependencies that we intentionally ignored when loading this
     /// package graph. Used to produce helpful diagnostics.
     var ignoredTransitiveDependencies: [PackageReference]
+    /// The set of traits enabled for each package.
+    var enabledTraits: [PackageReference: Set<String>]
 
     /// Gets the package referred to by the given package reference.
     /// - Parameter packageReference: The package reference.
@@ -215,26 +217,25 @@ extension SwiftPackageManager {
     /// - Throws: If any required packages, products, or targets cannot be found.
     /// - Returns: The targets contained within the product both directly and
     ///   transitively.
-    func transitiveTargets(
+    func transitiveActiveTargets(
       inProduct product: String,
-      inPackage packageReference: PackageReference
-    ) throws(Error) -> [ConditionalTargetReference] {
+      inPackage packageReference: PackageReference,
+      targetPlatform: Platform
+    ) throws(Error) -> [TargetReference] {
       let directTargets = try targets(
         ofProduct: product,
         inPackage: packageReference
       )
 
       let indirectTargets = try directTargets.flatMap { (target) throws(Error) in
-        return try transitiveTargetDependencies(
+        return try transitiveActiveTargetDependencies(
           ofTarget: target.name,
-          inPackage: target.package
+          inPackage: target.package,
+          targetPlatform: targetPlatform
         )
       }
 
-      let targets = directTargets.map { target in
-        ConditionalTargetReference(target: target, conditions: [])
-      } + indirectTargets
-
+      let targets = directTargets + indirectTargets
       return targets.uniqued()
     }
 
@@ -249,11 +250,10 @@ extension SwiftPackageManager {
       withTargetPlatform targetPlatform: Platform
     ) -> [TargetReference] {
       references.compactMap { reference in
-        let conditionsSatisfied = reference.conditions.allSatisfy { condition in
-          condition.isSatisfied(targetPlatform: targetPlatform)
+        if reference.target.package.identity == "swift-metrics" {
+          print(reference.conditions)
         }
-
-        if conditionsSatisfied {
+        if reference.isActive(targetPlatform: targetPlatform, packageGraph: self) {
           return reference.target
         } else {
           return nil
@@ -270,25 +270,26 @@ extension SwiftPackageManager {
     /// Excludes macro and plugin dependencies, as the code from those does
     /// not end up in the final executable, which is all that Swift Bundler
     /// cares about.
-    func transitiveTargetDependencies(
+    func transitiveActiveTargetDependencies(
       ofTarget target: String,
-      inPackage packageReference: PackageReference
-    ) throws(Error) -> [ConditionalTargetReference] {
+      inPackage packageReference: PackageReference,
+      targetPlatform: Platform
+    ) throws(Error) -> [TargetReference] {
       let directDependencies = try directTargetDependencies(
         ofTarget: target,
-        inPackage: packageReference
+        inPackage: packageReference,
+        targetPlatform: targetPlatform
       )
 
       var remainingDependencies = directDependencies
-      var dependencies: [ConditionalTargetReference] = directDependencies
+      var dependencies: [TargetReference] = directDependencies
 
       while let dependency = remainingDependencies.popLast() {
         let nestedDirectDependencies = try directTargetDependencies(
-          ofTarget: dependency.target.name,
-          inPackage: dependency.target.package
-        ).map { nestedDependency in
-          nestedDependency.appendingConditions(dependency.conditions)
-        }
+          ofTarget: dependency.name,
+          inPackage: dependency.package,
+          targetPlatform: targetPlatform
+        )
 
         for dependency in nestedDirectDependencies {
           guard !dependencies.contains(dependency) else {
@@ -312,41 +313,49 @@ extension SwiftPackageManager {
     /// cares about.
     func directTargetDependencies(
       ofTarget target: String,
-      inPackage packageReference: PackageReference
-    ) throws(Error) -> [ConditionalTargetReference] {
+      inPackage packageReference: PackageReference,
+      targetPlatform: Platform
+    ) throws(Error) -> [TargetReference] {
       let package = try self.package(referredToBy: packageReference)
 
       guard let target = package.targets[target] else {
         throw Error(.targetNotFoundInPackage(target, packageReference))
       }
     
-      return try target.dependencies.flatMap { (dependency) throws(Error) in
+      let enabledTraits = enabledTraits[packageReference] ?? []
+      return try target.dependencies.flatMap { (dependency: TargetDependency) throws(Error) -> [TargetReference] in
         switch dependency {
           case .target(let name, let condition):
-            let targetReference = ConditionalTargetReference(
-              target: TargetReference(name: name, package: packageReference),
-              conditions: [condition].compactMap { $0 }
-            )
+            guard condition?.isSatisfied(
+              targetPlatform: targetPlatform,
+              enabledTraits: enabledTraits
+            ) != false else {
+              return []
+            }
+
+            let targetReference = TargetReference(name: name, package: packageReference)
 
             // Exclude macro and plugin targets as we're only interested in targets with
             // code that ends up in the final executable.
-            let dependencyTarget = try self.target(referredToBy: targetReference.target)
+            let dependencyTarget = try self.target(referredToBy: targetReference)
             if dependencyTarget.kind == .macro || dependencyTarget.kind == .plugin {
               return []
             }
 
             return [targetReference]
           case .product(let packageIdentity, let product, let condition):
+            guard condition?.isSatisfied(
+              targetPlatform: targetPlatform,
+              enabledTraits: enabledTraits
+            ) != false else {
+              return []
+            }
+
             let dependencyPackageReference = PackageReference(identity: packageIdentity)
             return try targets(
               ofProduct: product,
               inPackage: dependencyPackageReference
-            ).map { target in
-              ConditionalTargetReference(
-                target: target,
-                conditions: [condition].compactMap { $0 }
-              )
-            }
+            )
         }
       }
     }
@@ -363,10 +372,12 @@ extension SwiftPackageManager.PackageGraph {
       source: .local(path: URL(fileURLWithPath: "/dummy")),
       localCheckout: URL(fileURLWithPath: "/dummy"),
       dependencies: [],
+      traits: [],
       products: [:],
       targets: [:]
     ),
     dependencyPackages: [:],
-    ignoredTransitiveDependencies: []
+    ignoredTransitiveDependencies: [],
+    enabledTraits: [SwiftPackageManager.PackageReference(identity: "dummy"): []]
   )
 }

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageManifest.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageManifest.swift
@@ -169,23 +169,6 @@ struct PackageManifest: Sendable, Decodable {
         }
       }
     }
-
-    /// Gets the path to the given dependency's local checkout. If the dependency
-    /// is a local package dependency, then this returns the path to the
-    /// dependency's source on disk.
-    func localCheckout(packageDirectory: URL, checkoutsDirectory: URL) -> URL {
-      switch location {
-        case .fileSystem(let path):
-          return path
-        case .sourceControl(let location):
-          var name = location.lastPathComponent
-          let gitSuffix = ".git"
-          if name.hasSuffix(gitSuffix) {
-            name = String(name.dropLast(gitSuffix.count))
-          }
-          return checkoutsDirectory / name
-      }
-    }
   }
 
   var name: String

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageSource.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageSource.swift
@@ -7,5 +7,13 @@ extension SwiftPackageManager {
     case local(path: URL)
     /// A package loaded from a remote git repository.
     case remote(gitRepository: URL)
+
+    /// Whether the source is remote or not.
+    var isRemote: Bool {
+      switch self {
+        case .local: false
+        case .remote: true
+      }
+    }
   }
 }

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/PartialPackageDump.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/PartialPackageDump.swift
@@ -5,13 +5,15 @@ extension SwiftPackageManager {
     var dependencies: [Dependency]
     var products: [Product]
     var targets: [Target]
+    var traits: [Trait]
 
     /// A Partial decoding of package dependencies. We only need this for
-    /// associating the `nameForTargetDependencyResolutionOnly` values with
-    /// identities, so that's all we parse.
+    /// associating the `nameForTargetDependencyResolutionOnly` values and
+    /// trait values with identities, so that's all we parse.
     enum Dependency: Sendable, Decodable {
       case decoded(
         identity: String,
+        traits: [String],
         nameForTargetDependencyResolutionOnly: String?
       )
       case other
@@ -23,7 +25,12 @@ extension SwiftPackageManager {
 
       struct DTO: Decodable {
         var identity: String
+        var traits: [TraitReference]
         var nameForTargetDependencyResolutionOnly: String?
+      }
+
+      struct TraitReference: Decodable {
+        var name: String
       }
 
       init(from decoder: any Decoder) throws {
@@ -67,6 +74,7 @@ extension SwiftPackageManager {
 
         self = .decoded(
           identity: dto.identity,
+          traits: dto.traits.map(\.name),
           nameForTargetDependencyResolutionOnly:
             dto.nameForTargetDependencyResolutionOnly
         )
@@ -84,19 +92,22 @@ extension SwiftPackageManager {
       var dependencies: [TargetDependency]
     }
 
-    enum DependencyCondition: Sendable, Decodable {
-      case platform(names: [String])
-      case unknown
+    struct DependencyCondition: Sendable, Decodable {
+      var platforms: [String]
+      var traits: [String]?
 
       enum CodingKeys: String, CodingKey {
         case platformNames
+        case traits
       }
 
       init(from decoder: any Decoder) throws {
         do {
           let container = try decoder.container(keyedBy: CodingKeys.self)
-          let platformNames = try container.decode([String].self, forKey: .platformNames)
-          self = .platform(names: platformNames)
+          platforms = try container.decode([String].self, forKey: .platformNames)
+          if container.contains(.traits) {
+            self.traits = try container.decode([String].self, forKey: .traits)
+          }
         } catch {
           log.warning(
             """
@@ -105,7 +116,8 @@ extension SwiftPackageManager {
             \(error.localizedDescription)
             """
           )
-          self = .unknown
+          platforms = []
+          traits = []
         }
       }
     }
@@ -177,6 +189,16 @@ extension SwiftPackageManager {
           self = .unknown
         }
       }
+    }
+
+    /// A package trait definition.
+    struct Trait: Sendable, Decodable {
+      /// The traits human-facing description.
+      var description: String?
+      /// Traits that this trait transitively enables.
+      var enabledTraits: [String]
+      /// The name of the trait (used to reference the trait in package manifests).
+      var name: String
     }
   }
 }

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+DefaultPackageLoader.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+DefaultPackageLoader.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+extension SwiftPackageManager {
+  /// The default package loader used by ``SwiftPackageManager``.
+  struct DefaultPackageLoader: PackageLoader {
+    func prepare(
+      packageDirectory: URL,
+      toolchain: URL?
+    ) async throws(Error) {
+      try await SwiftPackageManager.resolveDependencies(
+        packageDirectory: packageDirectory,
+        toolchain: toolchain
+      )
+    }
+
+    func loadPackage(
+      packageDirectory: URL,
+      source: PackageSource,
+      identityOverride: String?,
+      isRootPackage: Bool,
+      configurationContext: ConfigurationFlattener.Context,
+      toolchain: URL?
+    ) async throws(SwiftPackageManager.Error) -> Package<PackageDependency> {
+      let manifest = try await loadPackageManifest(from: packageDirectory, toolchain: toolchain)
+      let partialManifest = try await loadPartialPackageDump(
+        packageDirectory: packageDirectory,
+        toolchain: toolchain
+      )
+      let packageName = manifest.name
+      let packageIdentity = identityOverride ?? packageIdentity(forPackageWithName: packageName)
+
+      let products = SwiftPackageManager.products(
+        forManifest: manifest,
+        partialManifest: partialManifest,
+        isRootPackage: isRootPackage
+      )
+
+      let targets = SwiftPackageManager.targets(
+        forManifest: manifest,
+        partialManifest: partialManifest,
+        products: products,
+        packageName: packageName,
+        packageIdentity: packageIdentity,
+        packageDirectory: packageDirectory
+      )
+
+      // Load the package's bundler config file if present.
+      let fullConfiguration: PackageConfiguration?
+      let configuration: PackageConfiguration.Flat?
+      if PackageConfiguration.standardConfigurationFileLocation(for: packageDirectory).exists() {
+        let loadedConfiguration = try await Error.catch {
+          try await PackageConfiguration.load(fromDirectory: packageDirectory)
+        }
+        fullConfiguration = loadedConfiguration
+        configuration = try Error.catch {
+          try ConfigurationFlattener.flatten(
+            loadedConfiguration,
+            with: configurationContext
+          )
+        }
+      } else {
+        fullConfiguration = nil
+        configuration = nil
+      }
+
+      var traitsTable: [String: Set<String>] = [:]
+      for dependency in partialManifest.dependencies {
+        switch dependency {
+          case .decoded(let identity, let traits, _):
+            traitsTable[identity] = Set(traits)
+          case .other:
+            break
+        }
+      }
+
+      var dependencies: [PackageDependency] = []
+      for dependency in manifest.dependencies {
+        dependencies.append(
+          PackageDependency(
+            package: PackageReference(identity: dependency.identity),
+            traits: traitsTable[dependency.identity] ?? [],
+            location: dependency.location
+          )
+        )
+      }
+
+      let traits = partialManifest.traits.map { trait in
+        Trait(
+          name: trait.name,
+          description: trait.description,
+          enabledTraits: trait.enabledTraits
+        )
+      }
+
+      return Package(
+        name: packageName,
+        identity: packageIdentity,
+        source: source,
+        localCheckout: packageDirectory,
+        dependencies: dependencies,
+        traits: traits,
+        products: products,
+        targets: targets,
+        fullConfiguration: fullConfiguration,
+        configuration: configuration
+      )
+    }
+  }
+}

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+DefaultPackageLoader.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+DefaultPackageLoader.swift
@@ -21,6 +21,10 @@ extension SwiftPackageManager {
       configurationContext: ConfigurationFlattener.Context,
       toolchain: URL?
     ) async throws(SwiftPackageManager.Error) -> Package<PackageDependency> {
+      if source.isRemote && !packageDirectory.exists() {
+        throw Error(.missingDependencyCheckout(packageDirectory))
+      }
+
       let manifest = try await loadPackageManifest(from: packageDirectory, toolchain: toolchain)
       let partialManifest = try await loadPartialPackageDump(
         packageDirectory: packageDirectory,

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+Package.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+Package.swift
@@ -18,7 +18,7 @@ extension SwiftPackageManager {
     isRootPackage: Bool,
     configurationContext: ConfigurationFlattener.Context,
     toolchain: URL?
-  ) async throws(Error) -> Package<PackageManifest.PackageDependency> {
+  ) async throws(Error) -> Package<PackageDependency> {
     let manifest = try await loadPackageManifest(from: packageDirectory, toolchain: toolchain)
     let partialManifest = try await loadPartialPackageDump(
       packageDirectory: packageDirectory,
@@ -61,12 +61,42 @@ extension SwiftPackageManager {
       configuration = nil
     }
 
+    var traitsTable: [String: Set<String>] = [:]
+    for dependency in partialManifest.dependencies {
+      switch dependency {
+        case .decoded(let identity, let traits, _):
+          traitsTable[identity] = Set(traits)
+        case .other:
+          break
+      }
+    }
+
+    var dependencies: [PackageDependency] = []
+    for dependency in manifest.dependencies {
+      dependencies.append(
+        PackageDependency(
+          package: PackageReference(identity: dependency.identity),
+          traits: traitsTable[dependency.identity] ?? [],
+          location: dependency.location
+        )
+      )
+    }
+
+    let traits = partialManifest.traits.map { trait in
+      Trait(
+        name: trait.name,
+        description: trait.description,
+        enabledTraits: trait.enabledTraits
+      )
+    }
+
     return Package(
       name: packageName,
       identity: packageIdentity,
       source: source,
       localCheckout: packageDirectory,
-      dependencies: manifest.dependencies,
+      dependencies: dependencies,
+      traits: traits,
       products: products,
       targets: targets,
       fullConfiguration: fullConfiguration,
@@ -200,7 +230,7 @@ extension SwiftPackageManager {
     for dependency in manifest.dependencies {
       let resolutionName = partialManifest.dependencies.compactMap { partialDependency in
         switch partialDependency {
-          case .decoded(let identity, .some(let resolutionName))
+          case .decoded(let identity, _, .some(let resolutionName))
               where identity == dependency.identity:
             resolutionName
           default:
@@ -246,22 +276,13 @@ extension SwiftPackageManager {
     }
 
     let condition: TargetDependency.Condition?
-    switch partialCondition {
-      case .platform(let names):
-        condition = .platform(names: names)
-      case .unknown:
-        log.warning(
-          """
-          Target '\(target.name)' in package '\(packageName)' has a \
-          dependency condition that we failed to parse. Please open an issue at \
-          \(SwiftBundler.newIssueURL), as this is likely due to a newer \
-          Swift version breaking our parsing. Treating condition as \
-          unconditionally true.
-          """
-        )
-        condition = nil
-      case .none:
-        condition = nil
+    if let partialCondition {
+      condition = TargetDependency.Condition(
+        platforms: partialCondition.platforms,
+        traits: partialCondition.traits ?? []
+      )
+    } else {
+      condition = nil
     }
 
     /// Gets the normalized package identity of the dependency with the

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+Package.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+Package.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 extension SwiftPackageManager {
+  /// The package loader local to the current task. Overwritten by tests.
+  @TaskLocal static var packageLoader: any PackageLoader = DefaultPackageLoader()
+
   /// Loads the given package.
   /// - Parameters:
   ///   - packageDirectory: The root directory of the package to load.
@@ -8,6 +11,8 @@ extension SwiftPackageManager {
   ///   - identityOverride: The package's identity according to whichever package
   ///     is depending on this package (if any). If `nil` then the package's name
   ///     field is lowercased to obtain its identity according to itself.
+  ///   - isRootPackage: Whether the package is the root package or not. Affects which
+  ///     products are loaded.
   ///   - configurationContext: The context to use when flattening package configurations.
   ///   - toolchain: The Swift toolchain to use.
   /// - Returns: The loaded package.
@@ -19,88 +24,13 @@ extension SwiftPackageManager {
     configurationContext: ConfigurationFlattener.Context,
     toolchain: URL?
   ) async throws(Error) -> Package<PackageDependency> {
-    let manifest = try await loadPackageManifest(from: packageDirectory, toolchain: toolchain)
-    let partialManifest = try await loadPartialPackageDump(
+    try await packageLoader.loadPackage(
       packageDirectory: packageDirectory,
-      toolchain: toolchain
-    )
-    let packageName = manifest.name
-    let packageIdentity = identityOverride ?? packageIdentity(forPackageWithName: packageName)
-
-    let products = products(
-      forManifest: manifest,
-      partialManifest: partialManifest,
-      isRootPackage: isRootPackage
-    )
-
-    let targets = targets(
-      forManifest: manifest,
-      partialManifest: partialManifest,
-      products: products,
-      packageName: packageName,
-      packageIdentity: packageIdentity,
-      packageDirectory: packageDirectory
-    )
-
-    // Load the package's bundler config file if present.
-    let fullConfiguration: PackageConfiguration?
-    let configuration: PackageConfiguration.Flat?
-    if PackageConfiguration.standardConfigurationFileLocation(for: packageDirectory).exists() {
-      let loadedConfiguration = try await Error.catch {
-        try await PackageConfiguration.load(fromDirectory: packageDirectory)
-      }
-      fullConfiguration = loadedConfiguration
-      configuration = try Error.catch {
-        try ConfigurationFlattener.flatten(
-          loadedConfiguration,
-          with: configurationContext
-        )
-      }
-    } else {
-      fullConfiguration = nil
-      configuration = nil
-    }
-
-    var traitsTable: [String: Set<String>] = [:]
-    for dependency in partialManifest.dependencies {
-      switch dependency {
-        case .decoded(let identity, let traits, _):
-          traitsTable[identity] = Set(traits)
-        case .other:
-          break
-      }
-    }
-
-    var dependencies: [PackageDependency] = []
-    for dependency in manifest.dependencies {
-      dependencies.append(
-        PackageDependency(
-          package: PackageReference(identity: dependency.identity),
-          traits: traitsTable[dependency.identity] ?? [],
-          location: dependency.location
-        )
-      )
-    }
-
-    let traits = partialManifest.traits.map { trait in
-      Trait(
-        name: trait.name,
-        description: trait.description,
-        enabledTraits: trait.enabledTraits
-      )
-    }
-
-    return Package(
-      name: packageName,
-      identity: packageIdentity,
       source: source,
-      localCheckout: packageDirectory,
-      dependencies: dependencies,
-      traits: traits,
-      products: products,
-      targets: targets,
-      fullConfiguration: fullConfiguration,
-      configuration: configuration
+      identityOverride: identityOverride,
+      isRootPackage: isRootPackage,
+      configurationContext: configurationContext,
+      toolchain: toolchain
     )
   }
 
@@ -117,7 +47,7 @@ extension SwiftPackageManager {
   ///     target dependencies.
   ///   - packageIdentity: The package's identity in the package graph.
   ///   - packageDirectory: The root directory of the package.
-  private static func targets(
+  static func targets(
     forManifest manifest: PackageManifest,
     partialManifest: PartialPackageDump,
     products: [String: Product],
@@ -351,7 +281,7 @@ extension SwiftPackageManager {
   ///     `swift package dump-package` command. We only load as much information
   ///   - isRootPackage: Whether the package is the root package in the package
   ///     graph. This affects whether we load 'implicit' executable products or not.
-  private static func products(
+  static func products(
     forManifest manifest: PackageManifest,
     partialManifest: PartialPackageDump,
     isRootPackage: Bool

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+PackageGraph.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+PackageGraph.swift
@@ -27,7 +27,7 @@ extension SwiftPackageManager {
     toolchain: URL?
   ) async throws(Error) -> PackageGraph {
     log.info("Resolving dependencies")
-    try await SwiftPackageManager.resolveDependencies(
+    try await packageLoader.prepare(
       packageDirectory: packageDirectory,
       toolchain: toolchain
     )
@@ -68,6 +68,11 @@ extension SwiftPackageManager {
         )
       }
     }
+
+    // TODO(stackotter):
+    // - Create deterministic version of this for testing
+    // - Make package loader configurable so that we can mock the package
+    //   loader in tests
 
     let result: Result<(), Error> = await withTaskGroup(
       of: Result<[PackageDependency], Error>.self
@@ -272,7 +277,7 @@ extension SwiftPackageManager {
           ).isEmpty
 
           state.enabledTraits[dependencyReference, default: []].formUnion(enabledDependencyTraits)
-          if containsNewTraits, let dependencyPackage = state.dependencyPackages[reference] {
+          if containsNewTraits {
             // If we discovered more traits, we must attempt requeue the package's
             // dependencies recursively as new dependencies may have been enabled,
             // and new traits may have been passed on to the dependency's own

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+PackageGraph.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+PackageGraph.swift
@@ -4,8 +4,9 @@ import Mutex
 extension SwiftPackageManager {
   /// Shared mutable state used to coordinate the package graph loading process.
   private struct PackageGraphLoadingState: Sendable {
-    var coveredDependencies: [PackageReference] = []
-    var dependencyPackages: [PackageReference: Package<PackageReference>] = [:]
+    var coveredDependencies: Set<PackageReference> = []
+    var enabledTraits: [PackageReference: Set<String>] = [:]
+    var dependencyPackages: [PackageReference: Package<PackageDependency>] = [:]
     var ignoredTransitiveDependencies: [PackageReference] = []
   }
 
@@ -48,13 +49,14 @@ extension SwiftPackageManager {
 
     let state = Mutex(PackageGraphLoadingState(
       // We initially process all root dependencies, so mark them as covered straight away.
-      coveredDependencies: root.dependencies.map(\.identity).map(PackageReference.init(identity:)),
+      coveredDependencies: [root.reference],
+      enabledTraits: [root.reference: ["default"]],
       dependencyPackages: [:],
       ignoredTransitiveDependencies: []
     ))
 
     // A wrapper around 'processDependency' to make callsites more succinct (using captures)
-    let processDependency = { (dependency: PackageManifest.PackageDependency) async in
+    let processDependency = { (dependency: PackageDependency) async in
       return await Result.catching { () throws(Error) in
         try await Self.processDependency(
           dependency,
@@ -68,11 +70,21 @@ extension SwiftPackageManager {
     }
 
     let result: Result<(), Error> = await withTaskGroup(
-      of: Result<[PackageManifest.PackageDependency], Error>.self
+      of: Result<[PackageDependency], Error>.self
     ) { taskGroup in
-      for dependency in root.dependencies {
-        taskGroup.addTask {
-          await processDependency(dependency)
+      // Queue root dependencies (but only those that are used)
+      taskGroup.addTask {
+        await Result.catching { () throws(Error) in
+          var queue: [PackageDependency] = []
+          try state.withLock { (state) throws(Error) in
+            try queueTransitiveDependencies(
+              package: root,
+              state: &state,
+              into: &queue,
+              requirePublicUsage: false
+            )
+          }
+          return queue
         }
       }
 
@@ -100,8 +112,9 @@ extension SwiftPackageManager {
     let finalState = state.withLock { $0 }
     return PackageGraph(
       rootPackage: root.withReferences,
-      dependencyPackages: finalState.dependencyPackages,
-      ignoredTransitiveDependencies: finalState.ignoredTransitiveDependencies
+      dependencyPackages: finalState.dependencyPackages.mapValues(\.withReferences),
+      ignoredTransitiveDependencies: finalState.ignoredTransitiveDependencies,
+      enabledTraits: finalState.enabledTraits
     )
   }
 
@@ -167,13 +180,13 @@ extension SwiftPackageManager {
   ///     files contained within the dependency (if there are any).
   ///   - toolchain: The Swift toolchain to use when loading the dependency.
   private static func processDependency(
-    _ dependency: PackageManifest.PackageDependency,
+    _ dependency: PackageDependency,
     state: borrowing Mutex<PackageGraphLoadingState>,
     packageDirectory: URL,
     checkoutsDirectory: URL,
     configurationContext: ConfigurationFlattener.Context,
     toolchain: URL?
-  ) async throws(Error) -> [PackageManifest.PackageDependency] {
+  ) async throws(Error) -> [PackageDependency] {
     let dependencyDirectory = dependency.localCheckout(
       packageDirectory: packageDirectory,
       checkoutsDirectory: checkoutsDirectory
@@ -192,54 +205,117 @@ extension SwiftPackageManager {
     let package = try await loadPackage(
       packageDirectory: dependencyDirectory,
       source: source,
-      identityOverride: dependency.identity,
+      identityOverride: dependency.package.identity,
       isRootPackage: false,
       configurationContext: configurationContext,
       toolchain: toolchain
     )
     // END: Slow section
 
+    state.withLock { state in
+      // We've only just loaded the package, so any existing traits in
+      // state.enabledTraits won't have been recursively evaluated yet.
+      // We take care to recursively evaluate the whole union of traits
+      // rather than just those passed in from the particular dependency
+      // edge that got us here.
+      let enabledTraits = package.recursivelyEnabledTraits(
+        enabledTraits: Set(dependency.traits)
+          .union(state.enabledTraits[dependency.package] ?? [])
+      )
+      state.enabledTraits[dependency.package] = enabledTraits
+    }
+
+    var queuedDependencies: [PackageDependency] = []
+    try state.withLock { state throws(Error) in
+      try queueTransitiveDependencies(
+        package: package,
+        state: &state,
+        into: &queuedDependencies
+      )
+    }
+    return queuedDependencies
+  }
+
+  private static func queueTransitiveDependencies(
+    package: Package<PackageDependency>,
+    state: inout PackageGraphLoadingState,
+    into queuedDependencies: inout [PackageDependency],
+    requirePublicUsage: Bool = true
+  ) throws(Error) {
     let reference = PackageReference(identity: package.identity)
+
+    let enabledTraits = package.recursivelyEnabledTraits(
+      enabledTraits: state.enabledTraits[reference] ?? []
+    )
 
     /// Determine transitive dependencies that are yet to be loaded and return
     /// them for further processing.
-    var queuedDependencies: [PackageManifest.PackageDependency] = []
-    try state.withLock { state throws(Error) in
-      state.dependencyPackages[reference] = package.withReferences
+    state.dependencyPackages[reference] = package
 
-      for transitiveDependency in package.dependencies {
-        // Make sure that we haven't covered this dependency yet
-        let dependencyReference = PackageReference(identity: transitiveDependency.identity)
-        guard
-          !state.coveredDependencies.contains(
-            where: { $0.identity == transitiveDependency.identity }
-          )
-        else {
-          continue
+    for transitiveDependency in package.dependencies {
+      // Make sure that we haven't covered this dependency yet
+      let dependencyReference = transitiveDependency.package
+
+      guard !state.coveredDependencies.contains(dependencyReference) else {
+        if let dependencyPackage = state.dependencyPackages[dependencyReference] {
+          // The package has already been loaded, so we have to check whether this
+          // dependency edge contains any new traits that haven't been enabled yet
+          let enabledDependencyTraits = Set(dependencyPackage.recursivelyEnabledTraits(
+            enabledTraits: transitiveDependency.traits
+          ))
+
+          // The package has been loaded, so the state.enabledTraits entry for this
+          // package has already been recursively evaluated; we can just subtract them
+          // to get the set of new traits.
+          let containsNewTraits = !enabledDependencyTraits.subtracting(
+            state.enabledTraits[dependencyReference] ?? []
+          ).isEmpty
+
+          state.enabledTraits[dependencyReference, default: []].formUnion(enabledDependencyTraits)
+          if containsNewTraits, let dependencyPackage = state.dependencyPackages[reference] {
+            // If we discovered more traits, we must attempt requeue the package's
+            // dependencies recursively as new dependencies may have been enabled,
+            // and new traits may have been passed on to the dependency's own
+            // dependencies
+            try queueTransitiveDependencies(
+              package: dependencyPackage,
+              state: &state,
+              into: &queuedDependencies
+            )
+          }
+        } else {
+          // We can't compute the set of all traits recursively enabled yet,
+          // because we haven't loaded the package, so we just store them in
+          // the look up table and they will get evaluated properly when the
+          // package gets loaded
+          state.enabledTraits[dependencyReference, default: []]
+            .formUnion(transitiveDependency.traits)
         }
-
-        let isUsed = try dependencyIsPubliclyUsed(
-          dependency: transitiveDependency,
-          package: package
-        )
-
-        logDependency(
-          dependencyReference,
-          packageIdentity: package.identity,
-          ignored: !isUsed,
-          ignoredTransitiveDependencies: &state.ignoredTransitiveDependencies
-        )
-
-        guard isUsed else {
-          continue
-        }
-
-        state.coveredDependencies.append(dependencyReference)
-        queuedDependencies.append(transitiveDependency)
+        
+        continue
       }
-    }
 
-    return queuedDependencies
+      let isUsed = try dependencyIsUsed(
+        dependency: transitiveDependency,
+        package: package,
+        enabledTraits: enabledTraits,
+        onlyCountPublicUsage: requirePublicUsage
+      )
+
+      logDependency(
+        dependencyReference,
+        packageIdentity: package.identity,
+        ignored: !isUsed,
+        ignoredTransitiveDependencies: &state.ignoredTransitiveDependencies
+      )
+
+      guard isUsed else {
+        continue
+      }
+
+      state.coveredDependencies.insert(dependencyReference)
+      queuedDependencies.append(transitiveDependency)
+    }
   }
 
   /// Logs debug messages regarding our decision to ignore or load a given
@@ -277,49 +353,69 @@ extension SwiftPackageManager {
     }
   }
 
-  /// Computes whether a given dependency is used publicly by a package. This aims
+  /// Computes whether a given dependency is used by a package. This aims
   /// to reproduce the logic used by SwiftPM to decide whether to include a given
   /// transitive dependency in package resolution or not.
   /// - Parameters:
   ///   - dependency: The dependency to check for usage of.
   ///   - package: The package to check for usage within.
-  private static func dependencyIsPubliclyUsed(
-    dependency: PackageManifest.PackageDependency,
-    package: Package<PackageManifest.PackageDependency>
+  ///   - enabledTraits: The set of traits enabled for the package to check for
+  ///     usage within.
+  ///   - onlyCountPublicUsage: When resolving dependencies of a non-root package,
+  ///     only publicly used dependencies get checked out. This parameter emulates
+  ///     that behavior.
+  private static func dependencyIsUsed(
+    dependency: PackageDependency,
+    package: Package<PackageDependency>,
+    enabledTraits: Set<String>,
+    onlyCountPublicUsage: Bool
   ) throws(Error) -> Bool {
-    // Only load a transitive dependency if it's used by a product, because
-    // anything else gets counted as an internal detail by SwiftPM, which
-    // leads to SwiftPM not checking out said dependency.
-
-    let directlyUsedTargets = package.products
-      .filter { _, product in
-        switch product.productType {
-          case .executable, .library:
-            return true
-          case .macro, .plugin:
-            return false
+    var queue: [Target]
+    if onlyCountPublicUsage {
+      // Only load a transitive dependency if it's used by a product, because
+      // anything else gets counted as an internal detail by SwiftPM, which
+      // leads to SwiftPM not checking out said dependency.
+      let directlyUsedTargets = package.products
+        .filter { _, product in
+          switch product.productType {
+            case .executable, .library:
+              return true
+            case .macro, .plugin:
+              return false
+          }
         }
-      }
-      .flatMap(\.value.targets)
+        .flatMap(\.value.targets)
 
-    var queue = Array(
-      package.targets.filter { targetName, _ in
-        directlyUsedTargets.contains(targetName)
-      }.values
-    )
+      queue = Array(
+        package.targets.filter { targetName, _ in
+          directlyUsedTargets.contains(targetName)
+        }.values
+      )
+    } else {
+      queue = Array(package.targets.values)
+    }
+
     var seen = Set(queue.map(\.name))
 
     while let target = queue.popLast() {
       for targetDependency in target.dependencies {
         switch targetDependency {
-          case .product(let packageIdentity, _, _):
-            if dependency.identity == packageIdentity {
+          case .product(let packageIdentity, _, let condition):
+            guard condition?.traitClauseIsSatisfied(by: enabledTraits) ?? true else {
+              continue
+            }
+
+            if dependency.package.identity == packageIdentity {
               return true
             }
-          case .target(let targetName, _):
+          case .target(let targetName, let condition):
             if seen.insert(targetName).inserted {
               guard let target = package.targets[targetName] else {
                 throw Error(.targetNotFoundInPackage(targetName, package.reference))
+              }
+
+              guard condition?.traitClauseIsSatisfied(by: enabledTraits) ?? true else {
+                continue
               }
 
               switch target.kind {

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+PackageGraph.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+PackageGraph.swift
@@ -69,11 +69,6 @@ extension SwiftPackageManager {
       }
     }
 
-    // TODO(stackotter):
-    // - Create deterministic version of this for testing
-    // - Make package loader configurable so that we can mock the package
-    //   loader in tests
-
     let result: Result<(), Error> = await withTaskGroup(
       of: Result<[PackageDependency], Error>.self
     ) { taskGroup in
@@ -197,10 +192,6 @@ extension SwiftPackageManager {
       checkoutsDirectory: checkoutsDirectory
     )
 
-    if dependency.location.isRemote && !dependencyDirectory.exists() {
-      throw Error(.missingDependencyCheckout(dependencyDirectory))
-    }
-
     let source = switch dependency.location {
       case .fileSystem(let path): PackageSource.local(path: path)
       case .sourceControl(let url): PackageSource.remote(gitRepository: url)
@@ -272,9 +263,10 @@ extension SwiftPackageManager {
           // The package has been loaded, so the state.enabledTraits entry for this
           // package has already been recursively evaluated; we can just subtract them
           // to get the set of new traits.
-          let containsNewTraits = !enabledDependencyTraits.subtracting(
+          let newTraits = enabledDependencyTraits.subtracting(
             state.enabledTraits[dependencyReference] ?? []
-          ).isEmpty
+          )
+          let containsNewTraits = !newTraits.isEmpty
 
           state.enabledTraits[dependencyReference, default: []].formUnion(enabledDependencyTraits)
           if containsNewTraits {
@@ -282,6 +274,12 @@ extension SwiftPackageManager {
             // dependencies recursively as new dependencies may have been enabled,
             // and new traits may have been passed on to the dependency's own
             // dependencies
+            log.debug(
+              """
+              Requeueing \(dependencyPackage.name) for dependency processing \
+              because of new traits: \(newTraits)
+              """
+            )
             try queueTransitiveDependencies(
               package: dependencyPackage,
               state: &state,
@@ -293,6 +291,12 @@ extension SwiftPackageManager {
           // because we haven't loaded the package, so we just store them in
           // the look up table and they will get evaluated properly when the
           // package gets loaded
+          log.debug(
+            """
+            Updating stored traits for \(dependencyReference) to add \
+            \(transitiveDependency.traits) (package not loaded yet)
+            """
+          )
           state.enabledTraits[dependencyReference, default: []]
             .formUnion(transitiveDependency.traits)
         }

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+PackageLoader.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/SwiftPackageManager+PackageLoader.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+extension SwiftPackageManager {
+  /// A loader for Swift packages.
+  protocol PackageLoader: Sendable {
+    /// Prepares a package for package graph loading. This should perform any
+    /// setup required to load both the package itself and all of its active
+    /// dependencies. The default loader implements this by running
+    /// `swift package resolve`.
+    /// - Parameters:
+    ///   - packageDirectory: The directory of the root package.
+    ///   - toolchain: The Swift toolchain to use.
+    func prepare(
+      packageDirectory: URL,
+      toolchain: URL?
+    ) async throws(Error)
+
+    /// Loads a package.
+    /// - Parameters:
+    ///   - packageDirectory: The root directory of the package to load.
+    ///   - source: The original source of the package.
+    ///   - identityOverride: The package's identity according to whichever package
+    ///     is depending on this package (if any). If `nil` then the package's name
+    ///     field is lowercased to obtain its identity according to itself.
+    ///   - isRootPackage: Whether the package is the root package or not. If
+    ///     not the root package, SwiftPM filters out certain products, and
+    ///     implementations of this method should too.
+    ///   - configurationContext: Context to use when loading Swift Bundler
+    ///     configuration files from packages.
+    ///   - toolchain: The Swift toolchain to use.
+    /// - Returns: The package.
+    func loadPackage(
+      packageDirectory: URL,
+      source: PackageSource,
+      identityOverride: String?,
+      isRootPackage: Bool,
+      configurationContext: ConfigurationFlattener.Context,
+      toolchain: URL?
+    ) async throws(Error) -> Package<PackageDependency>
+  }
+}

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/TargetDependency.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/TargetDependency.swift
@@ -7,19 +7,39 @@ extension SwiftPackageManager {
     case product(packageIdentity: String, product: String, condition: Condition?)
 
     /// A condition that must be satisfied for a target dependency to be active.
-    enum Condition: Codable, Sendable, Hashable {
-      /// A condition that's only active when the target platform is contained
-      /// within `names`.
-      case platform(names: [String])
+    struct Condition: Codable, Sendable, Hashable {
+      /// If the platforms array is non-empty, then the condition requires the
+      /// current platform to be contained within this array.
+      var platforms: [String]
+      /// If the traits array is non-empty, then the condition requires at least
+      /// one of the listed traits to be enabled.
+      var traits: [String]
 
-      /// Gets whether the condition is satisfied when targeting the given platform.
-      /// - Parameter targetPlatform: The target platform.
+      /// Checks whether the condition is satisfied when targeting the given platform
+      /// with the given traits enabled.
+      /// - Parameters:
+      ///   - targetPlatform: The target platform.
+      ///   - enabledTraits: The traits enabled for this package (including
+      ///     traits transitively enabled by 'compound' traits).
       /// - Returns: Whether the condition is satisfied.
-      func isSatisfied(targetPlatform: Platform) -> Bool {
-        switch self {
-          case .platform(let names):
-            names.contains(targetPlatform.os.manifestConditionName)
-        }
+      func isSatisfied(targetPlatform: Platform, enabledTraits: Set<String>) -> Bool {
+        platformClauseIsSatisfied(by: targetPlatform)
+          && traitClauseIsSatisfied(by: enabledTraits)
+      }
+
+      /// Checks whether the platform clause of the condition is satisfied by
+      /// the given target platform.
+      func platformClauseIsSatisfied(by targetPlatform: Platform) -> Bool {
+        platforms.isEmpty
+          || platforms.contains(targetPlatform.os.manifestConditionName)
+      }
+
+      /// Checks whether the traits clause of the condition is satisfied by
+      /// the given set of enabled traits.
+      func traitClauseIsSatisfied(by enabledTraits: Set<String>) -> Bool {
+        // Ref: https://github.com/swiftlang/swift-package-manager/blob/05d6386648965d201676805b206c424008097f0b/Sources/PackageModel/Manifest/Manifest%2BTraits.swift#L393
+        traits.isEmpty
+          || !enabledTraits.intersection(traits).isEmpty
       }
     }
   }

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/Trait.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/Trait.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension SwiftPackageManager {
+  /// A package trait.
+  struct Trait: Codable, Sendable {
+    /// The name of the trait (used to reference the trait in package manifests).
+    var name: String
+    /// The traits human-facing description.
+    var description: String?
+    /// Traits that this trait transitively enables.
+    var enabledTraits: [String]
+  }
+}

--- a/Sources/SwiftBundler/SwiftBundlerErrorMapper.swift
+++ b/Sources/SwiftBundler/SwiftBundlerErrorMapper.swift
@@ -12,7 +12,7 @@ public enum SwiftBundlerErrorMapper: ErrorMapper {
         if codingKey.stringValue == "bundle_identifier" {
           return "'bundle_identifier' is required for app configuration to be migrated"
         } else {
-          let path = CodingPath(context.codingPath)
+          let path = CodingPath(context.codingPath + [codingKey])
           return "Expected a value at '\(path)'"
         }
       case let error as UnexpectedKeysError:

--- a/Tests/SwiftBundlerTests/Fixtures/Traits/.gitignore
+++ b/Tests/SwiftBundlerTests/Fixtures/Traits/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/SwiftBundlerTests/Fixtures/Traits/Library/.gitignore
+++ b/Tests/SwiftBundlerTests/Fixtures/Traits/Library/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/SwiftBundlerTests/Fixtures/Traits/Library/NestedDependency/.gitignore
+++ b/Tests/SwiftBundlerTests/Fixtures/Traits/Library/NestedDependency/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/SwiftBundlerTests/Fixtures/Traits/Library/NestedDependency/Package.swift
+++ b/Tests/SwiftBundlerTests/Fixtures/Traits/Library/NestedDependency/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.3
+
+import PackageDescription
+
+let package = Package(
+    name: "NestedDependency",
+    products: [
+        .library(
+            name: "NestedDependency",
+            targets: ["NestedDependency"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "NestedDependency"
+        ),
+        .testTarget(
+            name: "NestedDependencyTests",
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Tests/SwiftBundlerTests/Fixtures/Traits/Library/NestedDependency/Sources/NestedDependency/NestedDependency.swift
+++ b/Tests/SwiftBundlerTests/Fixtures/Traits/Library/NestedDependency/Sources/NestedDependency/NestedDependency.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Tests/SwiftBundlerTests/Fixtures/Traits/Library/Package.swift
+++ b/Tests/SwiftBundlerTests/Fixtures/Traits/Library/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 6.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Library",
+    products: [
+        .library(
+            name: "Library",
+            targets: ["Library"]
+        ),
+    ],
+    traits: [
+        .trait(
+            name: "MyTrait",
+            description: "Extra features"
+        ),
+        .default(enabledTraits: []),
+    ],
+    dependencies: [
+        .package(path: "NestedDependency"),
+    ],
+    targets: [
+        .target(
+            name: "Library",
+            dependencies: [
+                .product(
+                    name: "NestedDependency",
+                    package: "NestedDependency",
+                    condition: .when(traits: ["MyTrait"])
+                ),
+            ]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Tests/SwiftBundlerTests/Fixtures/Traits/Library/Sources/Library/Library.swift
+++ b/Tests/SwiftBundlerTests/Fixtures/Traits/Library/Sources/Library/Library.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Tests/SwiftBundlerTests/Fixtures/Traits/Package.swift
+++ b/Tests/SwiftBundlerTests/Fixtures/Traits/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Traits",
+    dependencies: [
+        .package(path: "Library", traits: ["MyTrait"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Traits",
+            dependencies: ["Library"]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Tests/SwiftBundlerTests/Fixtures/Traits/Sources/Traits/Traits.swift
+++ b/Tests/SwiftBundlerTests/Fixtures/Traits/Sources/Traits/Traits.swift
@@ -1,0 +1,9 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+@main
+struct Traits {
+    static func main() {
+        print("Hello, world!")
+    }
+}

--- a/Tests/SwiftBundlerTests/Mocks/MockError.swift
+++ b/Tests/SwiftBundlerTests/Mocks/MockError.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A basic error emitted by mocks.
+struct MockError: LocalizedError {
+  var message: String
+
+  var errorDescription: String? {
+    message
+  }
+
+  init(_ message: String) {
+    self.message = message
+  }
+}

--- a/Tests/SwiftBundlerTests/Mocks/MockPackageLoader.swift
+++ b/Tests/SwiftBundlerTests/Mocks/MockPackageLoader.swift
@@ -1,0 +1,47 @@
+import Foundation
+@testable import SwiftBundler
+
+/// The default package loader used by ``SwiftPackageManager``.
+///
+/// Loads hardcoded packages provided at the time of initialization. Packages
+/// are keyed by either an absolute path or a URL depending on whether they're
+/// a local package or a remote git package.
+struct MockPackageLoader: SwiftPackageManager.PackageLoader {
+  typealias Package = SwiftPackageManager.Package<SwiftPackageManager.PackageDependency>
+
+  var packages: [URL: Package]
+
+  init(packages: [URL: Package]) {
+    self.packages = packages
+  }
+
+  init(packages: [Package]) {
+    self.packages = Dictionary(uniqueKeysWithValues: packages.map { package in
+      (package.source.url, package)
+    })
+  }
+  
+  func prepare(
+    packageDirectory: URL,
+    toolchain: URL?
+  ) async throws(SwiftPackageManager.Error) {}
+
+  func loadPackage(
+    packageDirectory: URL,
+    source: SwiftPackageManager.PackageSource,
+    identityOverride: String?,
+    isRootPackage: Bool,
+    configurationContext: ConfigurationFlattener.Context,
+    toolchain: URL?
+  ) async throws(SwiftPackageManager.Error)
+    -> SwiftPackageManager.Package<SwiftPackageManager.PackageDependency>
+  {
+    let ident = source.url
+
+    guard let package = packages[ident] else {
+      throw SwiftPackageManager.Error(cause: MockError("No package at \(packageDirectory.path)"))
+    }
+
+    return package
+  }
+}

--- a/Tests/SwiftBundlerTests/Mocks/MockValues.swift
+++ b/Tests/SwiftBundlerTests/Mocks/MockValues.swift
@@ -1,0 +1,182 @@
+import Foundation
+@testable import SwiftBundler
+
+extension URL {
+  init(forPackage package: String) {
+    let identity = SwiftPackageManager.packageIdentity(forPackageWithName: package)
+    self.init(fileURLWithPath: "/\(identity)")
+  }
+}
+
+extension SwiftPackageManager.PackageSource {
+  var url: URL {
+    switch self {
+      case .local(let url), .remote(let url):
+        url
+    }
+  }
+}
+
+extension ConfigurationFlattener.Context {
+  static var mock: Self {
+    Self(
+      platform: .macOS,
+      bundler: .darwinApp,
+      architectures: [.arm64]
+    )
+  }
+}
+
+extension SwiftPackageManager.Package {
+  static func mock(
+    name: String,
+    identity: String? = nil,
+    source: SwiftPackageManager.PackageSource? = nil,
+    localCheckout: URL? = nil,
+    dependencies: [Dependency] = [],
+    traits: [SwiftPackageManager.Trait] = [],
+    products: [SwiftPackageManager.Product] = [],
+    targets: [SwiftPackageManager.Target] = [],
+    fullConfiguration: PackageConfiguration? = nil,
+    configuration: PackageConfiguration.Flat? = nil
+  ) -> Self {
+    let identity = identity ?? SwiftPackageManager.packageIdentity(forPackageWithName: name)
+    let localCheckout = localCheckout ?? URL(forPackage: identity)
+    return Self(
+      name: name,
+      identity: identity,
+      source: source ?? .local(path: localCheckout),
+      localCheckout: localCheckout,
+      dependencies: dependencies,
+      traits: traits,
+      products: Dictionary(uniqueKeysWithValues: products.map { product in
+        (product.name, product)
+      }),
+      targets: Dictionary(uniqueKeysWithValues: targets.map { target in
+        var target = target
+        let path = target.directory.path
+          .replacingOccurrences(of: "<package>", with: localCheckout.path)
+        target.directory = URL(fileURLWithPath: path)
+        return (target.name, target)
+      }),
+      fullConfiguration: fullConfiguration,
+      configuration: configuration
+    )
+  }
+}
+
+extension SwiftPackageManager.Target {
+  static func mock(
+    _ name: String,
+    kind: Kind,
+    directory: URL? = nil,
+    dependencies: [SwiftPackageManager.TargetDependency] = []
+  ) -> Self {
+    Self(
+      name: name,
+      kind: kind,
+      directory: directory ?? URL(fileURLWithPath: "<package>/Sources/\(name)"),
+      dependencies: dependencies
+    )
+  }
+
+  static func libraryMock(
+    _ name: String,
+    directory: URL? = nil,
+    dependencies: [SwiftPackageManager.TargetDependency] = []
+  ) -> Self {
+    mock(name, kind: .library, directory: directory, dependencies: dependencies)
+  }
+
+  static func executableMock(
+    _ name: String,
+    directory: URL? = nil,
+    dependencies: [SwiftPackageManager.TargetDependency] = []
+  ) -> Self {
+    mock(name, kind: .executable, directory: directory, dependencies: dependencies)
+  }
+}
+
+extension SwiftPackageManager.TargetDependency {
+  static func productMock(
+    _ product: String,
+    package: String? = nil,
+    condition: SwiftPackageManager.TargetDependency.Condition? = nil
+  ) -> Self {
+    let package = package ?? product
+    return .product(
+      packageIdentity: SwiftPackageManager.packageIdentity(forPackageWithName: package),
+      product: product,
+      condition: condition
+    )
+  }
+}
+
+extension SwiftPackageManager.PackageDependency {
+  static func mock(
+    _ package: String,
+    traits: Set<String> = [],
+    location: PackageManifest.PackageDependency.Location? = nil
+  ) -> Self {
+    let reference = SwiftPackageManager.PackageReference(name: package)
+    return Self(
+      package: reference,
+      traits: traits,
+      location: location ?? .fileSystem(path: URL(forPackage: reference.identity))
+    )
+  }
+}
+
+extension SwiftPackageManager.Product {
+  static func mock(
+    _ name: String,
+    productType: SwiftPackageManager.ProductType,
+    targets: [String]? = nil
+  ) -> Self {
+    Self(name: name, productType: productType, targets: targets ?? [name])
+  }
+
+  static func libraryMock(
+    _ name: String,
+    targets: [String]? = nil
+  ) -> Self {
+    .mock(name, productType: .library(linkingType: .automatic), targets: targets)
+  }
+
+  static func executableMock(
+    _ name: String,
+    targets: [String]? = nil
+  ) -> Self {
+    .mock(name, productType: .executable, targets: targets)
+  }
+}
+
+extension SwiftPackageManager.PackageReference: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(name: value)
+  }
+}
+
+extension SwiftPackageManager.TargetDependency.Condition {
+  static func mock(
+    platforms: [String] = [],
+    traits: [String] = []
+  ) -> Self {
+    Self(platforms: platforms, traits: traits)
+  }
+}
+
+extension SwiftPackageManager.Trait {
+  static func mock(
+    _ name: String,
+    enabledTraits: [String] = []
+  ) -> Self {
+    Self(name: name, enabledTraits: enabledTraits)
+  }
+}
+
+extension SwiftPackageManager.Trait: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(name: value, enabledTraits: [])
+  }
+}

--- a/Tests/SwiftBundlerTests/Mocks/MockValues.swift
+++ b/Tests/SwiftBundlerTests/Mocks/MockValues.swift
@@ -115,7 +115,7 @@ extension SwiftPackageManager.TargetDependency {
 extension SwiftPackageManager.PackageDependency {
   static func mock(
     _ package: String,
-    traits: Set<String> = [],
+    traits: Set<String> = ["default"],
     location: PackageManifest.PackageDependency.Location? = nil
   ) -> Self {
     let reference = SwiftPackageManager.PackageReference(name: package)

--- a/Tests/SwiftBundlerTests/Mocks/NaiveQueueExecutor.swift
+++ b/Tests/SwiftBundlerTests/Mocks/NaiveQueueExecutor.swift
@@ -13,10 +13,10 @@ private final class NaiveQueueExecutor: TaskExecutor, SerialExecutor {
     self.queue = queue
   }
 
-  func enqueue(_ _job: consuming ExecutorJob) {
-    let job = UnownedJob(_job)
+  func enqueue(_ job: consuming ExecutorJob) {
+    let unownedJob = UnownedJob(job)
     queue.async {
-      job.runSynchronously(
+      unownedJob.runSynchronously(
         isolatedTo: self.asUnownedSerialExecutor(),
         taskExecutor: self.asUnownedTaskExecutor()
       )
@@ -35,6 +35,11 @@ private final class NaiveQueueExecutor: TaskExecutor, SerialExecutor {
 }
 
 /// Runs the given operation on a serial task executor.
+///
+/// NOTE: If this function fails to compile, try using a newer Swift version.
+///   Swift 6.1 is known to fail on macOS, but we haven't bumped the overall
+///   package Swift tools version because we don't want the tests to dictate
+///   our supported Swift versions (given that tests don't affect consumers)
 func withSerialTaskExecutor<T, Failure: Error>(
   isolation: isolated (any Actor)? = #isolation,
   queueLabel: String = #function,
@@ -49,15 +54,19 @@ func withSerialTaskExecutor<T, Failure: Error>(
       operation: operation
     )
   } else {
-    // This is a fallback for older versions of macOS. The downside of this
-    // approach is that it affects every other test running in parallel for the
-    // duration of the operation because it overrides swift_task_enqueueGlobal_hook 
-    // to control task execution
-    let didUseMainSerialExecutor = ConcurrencyExtras.uncheckedUseMainSerialExecutor
-    defer {
-      ConcurrencyExtras.uncheckedUseMainSerialExecutor = didUseMainSerialExecutor
-    }
-    ConcurrencyExtras.uncheckedUseMainSerialExecutor = true
-    return try await operation()
+    #if os(macOS)
+      // This is a fallback for older versions of macOS. The downside of this
+      // approach is that it affects every other test running in parallel for the
+      // duration of the operation because it overrides swift_task_enqueueGlobal_hook 
+      // to control task execution
+      let didUseMainSerialExecutor = ConcurrencyExtras.uncheckedUseMainSerialExecutor
+      defer {
+        ConcurrencyExtras.uncheckedUseMainSerialExecutor = didUseMainSerialExecutor
+      }
+      ConcurrencyExtras.uncheckedUseMainSerialExecutor = true
+      return try await operation()
+    #else
+      fatalError("How did we get here?")
+    #endif
   }
 }

--- a/Tests/SwiftBundlerTests/Mocks/NaiveQueueExecutor.swift
+++ b/Tests/SwiftBundlerTests/Mocks/NaiveQueueExecutor.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+#if os(macOS)
+  import ConcurrencyExtras
+#endif
+
+// Source: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0417-task-executor-preference.md#combining-serialexecutor-and-taskexecutor
+@available(macOS 15, *)
+private final class NaiveQueueExecutor: TaskExecutor, SerialExecutor {
+  let queue: DispatchQueue
+
+  init(_ queue: DispatchQueue) {
+    self.queue = queue
+  }
+
+  func enqueue(_ _job: consuming ExecutorJob) {
+    let job = UnownedJob(_job)
+    queue.async {
+      job.runSynchronously(
+        isolatedTo: self.asUnownedSerialExecutor(),
+        taskExecutor: self.asUnownedTaskExecutor()
+      )
+    }
+  }
+
+  @inlinable
+  public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+
+  @inlinable
+  public func asUnownedTaskExecutor() -> UnownedTaskExecutor {
+    UnownedTaskExecutor(ordinary: self)
+  }
+}
+
+/// Runs the given operation on a serial task executor.
+func withSerialTaskExecutor<T, Failure: Error>(
+  isolation: isolated (any Actor)? = #isolation,
+  queueLabel: String = #function,
+  operation: () async throws(Failure) -> T
+) async throws(Failure) -> T {
+  if #available(macOS 15, *) {
+    let queue = DispatchQueue(label: queueLabel)
+    let executor = NaiveQueueExecutor(queue)
+    return try await withTaskExecutorPreference(
+      executor,
+      isolation: isolation,
+      operation: operation
+    )
+  } else {
+    // This is a fallback for older versions of macOS. The downside of this
+    // approach is that it affects every other test running in parallel for the
+    // duration of the operation because it overrides swift_task_enqueueGlobal_hook 
+    // to control task execution
+    let didUseMainSerialExecutor = ConcurrencyExtras.uncheckedUseMainSerialExecutor
+    defer {
+      ConcurrencyExtras.uncheckedUseMainSerialExecutor = didUseMainSerialExecutor
+    }
+    ConcurrencyExtras.uncheckedUseMainSerialExecutor = true
+    return try await operation()
+  }
+}

--- a/Tests/SwiftBundlerTests/PackageConfigurationTests.swift
+++ b/Tests/SwiftBundlerTests/PackageConfigurationTests.swift
@@ -134,7 +134,7 @@ struct PackageConfigurationTests {
           Issue.record(
             """
             Parsing a config file with a format_version > 3 must fail with an \
-            'unsupported format version' error, got '\(message)'
+            'unsupported format version' error, got '\(message?.userFriendlyMessage ?? "<none>")'
             """
           )
       }

--- a/Tests/SwiftBundlerTests/PackageGraphLoadingTests.swift
+++ b/Tests/SwiftBundlerTests/PackageGraphLoadingTests.swift
@@ -8,7 +8,8 @@ struct PackageGraphLoadingTests {
     URL(fileURLWithPath: path)
   }
 
-  @Test func simpleGraphLoading() async throws {
+  @Test("Ensure that we can load a simple package graph with two packages")
+  func simpleGraphLoading() async throws {
     let rootURL = URL(forPackage: "MyPackage")
     let loader = MockPackageLoader(
       packages: [
@@ -43,7 +44,10 @@ struct PackageGraphLoadingTests {
     #expect(graph.dependencyPackages.keys.contains("Library"))
   }
 
-  @Test(arguments: [true, false])
+  @Test(
+    "Ensure that trait-gated dependencies are correctly loaded/ignored",
+    arguments: [true, false]
+  )
   func traitGraphLoading(_ traitEnabled: Bool) async throws {
     let rootURL = URL(forPackage: "MyPackage")
     let enabledTraits: Set<String> = traitEnabled ? ["MyTrait"] : ["default"]
@@ -94,5 +98,135 @@ struct PackageGraphLoadingTests {
     #expect(graph.dependencyPackages.keys.contains("OptionalLibrary") == traitEnabled)
     #expect(graph.ignoredTransitiveDependencies == (traitEnabled ? [] : ["optionallibrary"]))
     #expect(graph.enabledTraits["Library"] == enabledTraits)
+  }
+  
+  @Test(
+    """
+    Ensure that the final state of the loaded package graph includes all active \
+    trait-gated dependencies (regardless of the order that traits were discovered in)
+    """,
+    arguments: [true, false]
+  )
+  func testDelayedLoading(_ libraryFirst: Bool) async throws {
+    // This package graph should have the same behaviour with both dependency
+    // orderings, but if SecondLibrary is second then the package graph
+    // loader has to be careful, because it will initially ignore OptionalLibrary
+    // because of the MyTrait requirement not being satisfied, and then it will
+    // have to reprocess Library once it reaches SecondLibrary and sees that it
+    // enables MyTrait.
+    let rootURL = URL(forPackage: "MyPackage")
+    let loader = MockPackageLoader(
+      packages: [
+        .mock(
+          name: "MyPackage",
+          dependencies: libraryFirst
+            ? [.mock("Library"), .mock("SecondLibrary")]
+            : [.mock("SecondLibrary"), .mock("Library")],
+          targets: [
+            .executableMock(
+              "Tool",
+              dependencies: [.productMock("Library"), .productMock("SecondLibrary")]
+            )
+          ]
+        ),
+        .mock(
+          name: "Library",
+          dependencies: [.mock("OptionalLibrary")],
+          traits: ["MyTrait"],
+          products: [.libraryMock("Library")],
+          targets: [
+            .libraryMock(
+              "Library",
+              dependencies: [
+                .productMock("OptionalLibrary", condition: .mock(traits: ["MyTrait"]))
+              ]
+            )
+          ]
+        ),
+        .mock(
+          name: "SecondLibrary",
+          dependencies: [.mock("Library", traits: ["MyTrait"])],
+          products: [.libraryMock("Library")],
+          targets: [
+            .libraryMock("SecondLibrary", dependencies: [.productMock("Library")]),
+          ]
+        ),
+        .mock(
+          name: "OptionalLibrary",
+          products: [.libraryMock("OptionalLibrary")],
+          targets: [.libraryMock("OptionalLibrary")]
+        )
+      ]
+    )
+
+    let graph = try await SwiftPackageManager.$packageLoader.withValue(loader) {
+      try await withSerialTaskExecutor {
+        try await SwiftPackageManager.loadPackageGraph(
+          packageDirectory: rootURL,
+          configurationContext: .mock,
+          toolchain: nil
+        )
+      }
+    }
+
+    #expect(graph.dependencyPackages.keys.contains("MyPackage"))
+    #expect(graph.dependencyPackages.keys.contains("Library"))
+    #expect(graph.dependencyPackages.keys.contains("SecondLibrary"))
+    #expect(graph.dependencyPackages.keys.contains("OptionalLibrary"))
+    #expect(graph.ignoredTransitiveDependencies == [])
+    #expect(graph.enabledTraits["Library"] == ["default", "MyTrait"])
+  }
+
+  @Test("Ensure that traits from inactive dependency edges still get respected")
+  func traitsFromUnusedDependencyEdges() async throws {
+    let rootURL = URL(forPackage: "MyPackage")
+    let remoteURL = URL(string: "https://example.com/packages/remote")!
+    let remoteSource = PackageManifest.PackageDependency.Location.sourceControl(url: remoteURL)
+    let loader = MockPackageLoader(
+      packages: [
+        .mock(
+          name: "MyPackage",
+          dependencies: [
+            .mock("Remote", location: remoteSource),
+            .mock("Library")
+          ],
+          targets: [
+            .executableMock(
+              "Tool",
+              dependencies: [
+                .productMock("Library"),
+                .productMock("Remote"),
+              ]
+            )
+          ]
+        ),
+        .mock(
+          name: "Library",
+          dependencies: [.mock("Remote", traits: ["MyTrait"], location: remoteSource)],
+          products: [.libraryMock("Library")],
+          targets: [.libraryMock("Library")]
+        ),
+        .mock(
+          name: "Remote",
+          source: .remote(gitRepository: remoteURL),
+          traits: ["MyTrait"],
+          products: [.libraryMock("Remote")],
+          targets: [.libraryMock("Library")]
+        )
+      ]
+    )
+
+    let graph = try await SwiftPackageManager.$packageLoader.withValue(loader) {
+      try await SwiftPackageManager.loadPackageGraph(
+        packageDirectory: rootURL,
+        configurationContext: .mock,
+        toolchain: nil
+      )
+    }
+
+    #expect(graph.dependencyPackages.keys.contains("MyPackage"))
+    #expect(graph.dependencyPackages.keys.contains("Library"))
+    #expect(graph.dependencyPackages.keys.contains("Remote"))
+    #expect(graph.enabledTraits["Remote"] == ["default", "MyTrait"])
   }
 }

--- a/Tests/SwiftBundlerTests/PackageGraphLoadingTests.swift
+++ b/Tests/SwiftBundlerTests/PackageGraphLoadingTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import SwiftBundler
+
+@Suite(.serialized)
+struct PackageGraphLoadingTests {
+  private func pathURL(_ path: String) -> URL {
+    URL(fileURLWithPath: path)
+  }
+
+  @Test func simpleGraphLoading() async throws {
+    let rootURL = URL(forPackage: "MyPackage")
+    let loader = MockPackageLoader(
+      packages: [
+        .mock(
+          name: "MyPackage",
+          dependencies: [.mock("Library")],
+          targets: [
+            .executableMock(
+              "Tool",
+              dependencies: [.productMock("Library")]
+            )
+          ]
+        ),
+        .mock(
+          name: "Library",
+          products: [.libraryMock("Library")],
+          targets: [.libraryMock("Library")]
+        )
+      ]
+    )
+
+    let graph = try await SwiftPackageManager.$packageLoader.withValue(loader) {
+      try await SwiftPackageManager.loadPackageGraph(
+        packageDirectory: rootURL,
+        configurationContext: .mock,
+        toolchain: nil
+      )
+    }
+
+    #expect(graph.ignoredTransitiveDependencies.isEmpty)
+    #expect(graph.dependencyPackages.keys.contains("MyPackage"))
+    #expect(graph.dependencyPackages.keys.contains("Library"))
+  }
+
+  @Test(arguments: [true, false])
+  func traitGraphLoading(_ traitEnabled: Bool) async throws {
+    let rootURL = URL(forPackage: "MyPackage")
+    let enabledTraits: Set<String> = traitEnabled ? ["MyTrait"] : ["default"]
+    let loader = MockPackageLoader(
+      packages: [
+        .mock(
+          name: "MyPackage",
+          dependencies: [.mock("Library", traits: enabledTraits)],
+          targets: [
+            .executableMock(
+              "Tool",
+              dependencies: [.productMock("Library")]
+            )
+          ]
+        ),
+        .mock(
+          name: "Library",
+          dependencies: [.mock("OptionalLibrary")],
+          traits: ["MyTrait"],
+          products: [.libraryMock("Library")],
+          targets: [
+            .libraryMock(
+              "Library",
+              dependencies: [
+                .productMock("OptionalLibrary", condition: .mock(traits: ["MyTrait"]))
+              ]
+            )
+          ]
+        ),
+        .mock(
+          name: "OptionalLibrary",
+          products: [.libraryMock("OptionalLibrary")],
+          targets: [.libraryMock("OptionalLibrary")]
+        )
+      ]
+    )
+
+    let graph = try await SwiftPackageManager.$packageLoader.withValue(loader) {
+      try await SwiftPackageManager.loadPackageGraph(
+        packageDirectory: rootURL,
+        configurationContext: .mock,
+        toolchain: nil
+      )
+    }
+
+    #expect(graph.dependencyPackages.keys.contains("MyPackage"))
+    #expect(graph.dependencyPackages.keys.contains("Library"))
+    #expect(graph.dependencyPackages.keys.contains("OptionalLibrary") == traitEnabled)
+    #expect(graph.ignoredTransitiveDependencies == (traitEnabled ? [] : ["optionallibrary"]))
+    #expect(graph.enabledTraits["Library"] == enabledTraits)
+  }
+}


### PR DESCRIPTION
This was more confusing than I would've expected, but I believe that it should be working now.

I'm yet to properly stress test this implementation with weird trait setups (e.g. ones that force the package graph to process a package's dependencies twice). I'll do that before merging this. For now I'm leaving it as a draft.

---

If you've ever wondered why trait-based target dependency conditions can't assert that a trait *isn't* present, it's to maintain a specific property of the traits system: when the package graph loader loads a package, the traits enabled by that package must never cause a previously-loaded package to exit the package graph. In other words, new information that the package loader discovers must only ever expand the package graph. Otherwise, my gut feeling tells me that you could end up with infinite loops that would make package resolution non-terminating.

On the other hand, SwiftPM always has all of the information it well ever know about the target platform before attempting to load the package graph, so it could probably allow arbitrarily complicated logic expressions in platform-based conditions, but it doesn't. The symmetry probably helps people stomach the limitations of traits a bit better anyway 🤷‍♂️