### PR TITLE
Include url_schemes in embedded app metadata

### DIFF
--- a/Sources/SwiftBundler/Bundler/MetadataInserter.swift
+++ b/Sources/SwiftBundler/Bundler/MetadataInserter.swift
@@ -17,8 +17,18 @@ enum MetadataInserter {
     var appIdentifier: String
     /// The app's version.
     var appVersion: Version
+    /// The app's declared URL schemes.
+    var urlSchemes: [URLScheme]?
     /// Additional user-defined metadata.
     var additionalMetadata: [String: MetadataValue]
+
+    /// A URL scheme. This is a struct instead of a string so that we can extend
+    /// the format with additional properties without breaking existing metadata
+    /// producers or extractors.
+    struct URLScheme: Codable {
+      /// The URL scheme itself.
+      var scheme: String
+    }
   }
 
   enum CompiledMetadata {
@@ -31,6 +41,9 @@ enum MetadataInserter {
     Metadata(
       appIdentifier: configuration.identifier,
       appVersion: configuration.version,
+      urlSchemes: configuration.urlSchemes.map { scheme in
+        Metadata.URLScheme(scheme: scheme)
+      },
       additionalMetadata: configuration.metadata
     )
   }

--- a/Sources/SwiftBundlerRuntime/Metadata.swift
+++ b/Sources/SwiftBundlerRuntime/Metadata.swift
@@ -6,7 +6,12 @@ import SwiftBundlerRuntimeC
 public struct Metadata {
   public var appIdentifier: String
   public var appVersion: String
+  public var urlSchemes: [URLScheme]?
   public var additionalMetadata: [String: Any]
+
+  public struct URLScheme: Codable {
+    var scheme: String
+  }
 
   /// Loads the app's embedded metadata if present and returns `nil` otherwise.
   /// - Throws: An error if metadata is present but malformed.
@@ -56,6 +61,23 @@ public struct Metadata {
           message: "Failed to parse metadata: missing app version"
         )
       }
+
+      let urlSchemes: [URLScheme]?
+      if let schemes = json["urlSchemes"] as? [Any] {
+        urlSchemes = try schemes.map { scheme in
+          guard
+            let scheme = scheme as? [String: Any],
+            let name = scheme["scheme"] as? String
+          else {
+            throw RuntimeError(
+              message: "Failed to parse metadata: invalid url schemes"
+            )
+          }
+          return URLScheme(scheme: name)
+        }
+      } else {
+        urlSchemes = nil
+      }
       
       let additionalMetadata = json["additionalMetadata"].map { value in
         value as? [String: Any] ?? [:]
@@ -64,6 +86,7 @@ public struct Metadata {
       return Metadata(
         appIdentifier: identifier,
         appVersion: version,
+        urlSchemes: urlSchemes,
         additionalMetadata: additionalMetadata
       )
     #else


### PR DESCRIPTION
This PR extends the Swift Bundler metadata format to include a urlSchemes field. I've hopefully managed to do this in a way that is backwards compatible. I've also taken care to make the format as extendable as possible in future by representing each URL scheme as a struct instead of as a string (allowing new fields to be added in future without breaking existing parsers).

This is necessary for supporting custom URL schemes in unpackaged Windows apps, because unpackaged Windows apps have to register URL protocol associations at runtime (rather than in static metadata files like on other platforms).