### PR TITLE
Windows: Sign unsigned DLLs when codesigning is enabled

### DIFF
--- a/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
+++ b/Sources/SwiftBundler/Bundler/GenericWindowsBundler.swift
@@ -427,7 +427,8 @@ enum GenericWindowsBundler: Bundler {
     try await copyDynamicLibraryDependencies(
       of: structure.mainExecutable,
       to: structure.modules,
-      productsDirectory: context.productsDirectory
+      productsDirectory: context.productsDirectory,
+      context: context
     )
   }
 
@@ -440,7 +441,8 @@ enum GenericWindowsBundler: Bundler {
   private static func copyDynamicLibraryDependencies(
     of module: URL,
     to destination: URL,
-    productsDirectory: URL
+    productsDirectory: URL,
+    context: BundlerContext
   ) async throws(Error) {
     let productsDirectory = productsDirectory.actuallyResolvingSymlinksInPath()
 
@@ -471,6 +473,24 @@ enum GenericWindowsBundler: Bundler {
         errorMessage: ErrorMessage.failedToCopyDLL
       )
 
+      if let codeSigningContext = context.windowsCodeSigningContext {
+        try await Error.catch {
+          // Don't re-sign the file if it's already signed (it was probably
+          // downloaded from the internet or built by an external build system
+          // that already handles signing). If the file has a signature but not
+          // one that we trust, then we proceed with re-signing the executable.
+          let isSigned = try await WindowsCodeSigner.fileHasTrustedSignature(destinationFile)
+          guard !isSigned else {
+            return
+          }
+
+          try await WindowsCodeSigner.signFile(
+            destinationFile,
+            context: codeSigningContext
+          )
+        }
+      }
+
       if pdbFile.exists() {
         // Copy dll's pdb file if present
         let destinationPDBFile = destinationFile.replacingPathExtension(
@@ -488,7 +508,8 @@ enum GenericWindowsBundler: Bundler {
       try await copyDynamicLibraryDependencies(
         of: resolvedSourceFile,
         to: destination,
-        productsDirectory: productsDirectory
+        productsDirectory: productsDirectory,
+        context: context
       )
     }
   }

--- a/Sources/SwiftBundler/Bundler/ProjectBuilder.swift
+++ b/Sources/SwiftBundler/Bundler/ProjectBuilder.swift
@@ -301,7 +301,7 @@ enum ProjectBuilder {
     }
 
     if !dryRun {
-      log.info("Copying product '\(dependency)'")
+      log.info("Copying product \(dependency)")
     }
 
     let artifactPaths = [productPath] + auxiliaryArtifactPaths

--- a/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageGraph.swift
+++ b/Sources/SwiftBundler/Bundler/SwiftPackageManager/PackageGraph.swift
@@ -135,11 +135,7 @@ extension SwiftPackageManager {
     internal func allProducts() -> [String: (PackageReference, Product)] {
       // blame is used when producing duplicate product name warnings
       var blame: [String: PackageReference] = [:]
-
-      var allProducts = rootPackage.products.mapValues { (rootPackage.reference, $0) }
-      for name in rootPackage.products.keys {
-        blame[name] = rootPackage.reference
-      }
+      var allProducts: [String: (PackageReference, Product)] = [:]
 
       for package in dependencyPackages.values {
         for (name, product) in package.products {


### PR DESCRIPTION
Some Windows security features (or anti virus programs) check DLL signatures even though the signatures aren't actually checked by Windows when loading them under normal circumstances.

This PR satisfies such security features/programs by signing all bundled DLLs that don't already have trusted signatures (e.g. we sign the Swift runtime DLLs, but not the visual c runtime DLLs).

---

This PR also bundles in a couple of error message/log message formatting issues, because I don't want to have to wait for CI more than I have to, and those changes are basically ineffectual IMO.